### PR TITLE
Drop setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     license = "MIT",
     keywords = ["bioinformatics", "genomics", "hi-c", "juicer", "cooler", "contact-matrix", "file-format"],
     install_requires = requires,
-    setup_requires = requires,
     tests_require = requires,
     test_suite = "test",
     entry_points = {


### PR DESCRIPTION
`setup_requires` should only contain those dependencies that are required by the `setup.py` script itself. Since the `setup.py` script doesn’t actually import any of the dependencies in the `requires` list, `setup_requires` can be removed entirely. This reduces installation time under some circumstances, and will also simplify the Bioconda package.