### PR TITLE
Allow hic2cool_updates.py to write output files

### DIFF
--- a/hic2cool/hic2cool_config.py
+++ b/hic2cool/hic2cool_config.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # Cooler metadata
 COOLER_FORMAT = "HDF5::Cooler"
-COOLER_FORMAT_VERSION = 2
+COOLER_FORMAT_VERSION = 3
 MCOOL_FORMAT = "HDF5::MCOOL"
 MCOOL_FORMAT_VERSION = 2
 URL = "https://github.com/4dn-dcic/hic2cool"

--- a/hic2cool/hic2cool_config.py
+++ b/hic2cool/hic2cool_config.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # Cooler metadata
 COOLER_FORMAT = "HDF5::Cooler"
-COOLER_FORMAT_VERSION = 3
+COOLER_FORMAT_VERSION = 2
 MCOOL_FORMAT = "HDF5::MCOOL"
 MCOOL_FORMAT_VERSION = 2
 URL = "https://github.com/4dn-dcic/hic2cool"

--- a/hic2cool/hic2cool_updates.py
+++ b/hic2cool/hic2cool_updates.py
@@ -87,7 +87,7 @@ def update_invert_weights(writefile):
         else:
             print('... Inverted following weights: %s' % found_weights)
 
-    with h5py.File(writefile) as h5_file:
+    with h5py.File(writefile, "r+") as h5_file:
         if 'resolutions' in h5_file:
             for res in h5_file['resolutions']:
                 update_invert_weight_for_resolution(h5_file['resolutions'][res]['bins'], res=res)
@@ -111,7 +111,7 @@ def update_cooler_schema_v3(writefile):
         else:
             print('... Added format-version and storage-mode attributes')
 
-    with h5py.File(writefile) as h5_file:
+    with h5py.File(writefile, "r+") as h5_file:
         if 'resolutions' in h5_file:
             for res in h5_file['resolutions']:
                 add_v3_attrs(h5_file['resolutions'][res], res=res)
@@ -123,7 +123,7 @@ def update_mcool_schema_v2(writefile):
     """
     Add format and format-version attributes to the base level of an mcool
     """
-    with h5py.File(writefile) as h5_file:
+    with h5py.File(writefile, "r+") as h5_file:
         # only run if it's an mcool and 'resolutions' exist
         if 'resolutions' in h5_file:
             mcool_info = {

--- a/hic2cool/hic2cool_updates.py
+++ b/hic2cool/hic2cool_updates.py
@@ -93,6 +93,7 @@ def update_invert_weights(writefile):
                 update_invert_weight_for_resolution(h5_file['resolutions'][res]['bins'], res=res)
         else:
             update_invert_weight_for_resolution(h5_file['bins'])
+        h5_file.close()
 
 
 def update_cooler_schema_v3(writefile):
@@ -117,6 +118,7 @@ def update_cooler_schema_v3(writefile):
                 add_v3_attrs(h5_file['resolutions'][res], res=res)
         else:
             add_v3_attrs(h5_file)
+       h5_file.close()
 
 
 def update_mcool_schema_v2(writefile):
@@ -134,3 +136,4 @@ def update_mcool_schema_v2(writefile):
             print('... Added format and format-version attributes for the mcool')
         else:
             print('... Not a multi-res file, so will not add mcool schema attributes')
+        h5_file.close()


### PR DESCRIPTION
Resolves this problem calling "hic2cool update ..." in the bash command line:

> Traceback (most recent call last):
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/bin/hic2cool", line 10, in <module>
    sys.exit(main())
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/hic2cool/__main__.py", line 88, in main
    hic2cool_update(args.infile, args.outfile, args.warnings, args.silent)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/hic2cool/hic2cool_utils.py", line 1159, in hic2cool_update
    run_hic2cool_updates(updates, infile, writefile)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/hic2cool/hic2cool_utils.py", line 812, in run_hic2cool_updates
    upd['function'](writefile)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/hic2cool/hic2cool_updates.py", line 117, in update_cooler_schema_v3
    add_v3_attrs(h5_file['resolutions'][res], res=res)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/hic2cool/hic2cool_updates.py", line 108, in add_v3_attrs
    h5_data.attrs.update(info)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/_collections_abc.py", line 941, in update
    self[key] = other[key]
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/h5py/_hl/attrs.py", line 103, in __setitem__
    self.create(name, data=value)
  File "/home/kelly-t/.conda/envs/conda/envs/mcool-v3/lib/python3.9/site-packages/h5py/_hl/attrs.py", line 196, in create
    attr = h5a.create(self._id, self._e(tempname), htype, space)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5a.pyx", line 50, in h5py.h5a.create
RuntimeError: Unable to create attribute (no write intent on file)

I checked this error occurred with both hic2cool v0.7.1 and 0.8.3.

Note that this workaround no longer works:
> Give write permissions to h5py package before saving your file.
> This should work : `h5py.get_config().default_file_mode = "w"`
https://stackoverflow.com/questions/57131048/unable-to-create-group-no-write-intent-on-file

Current versions of h5py only allow "r" as default permissions.  Note that "w" permissions will not allow reading the original files for "r+" or "a" is needed.
https://docs.h5py.org/en/stable/high/file.html