### PR TITLE
Restore command line usage and update documentation, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The hic parsing code is based off the [straw project](https://github.com/theaide
 $ pip install hic2cool
 ```
 
-You can also download the code directly and run the setup yourself.
+You can also download the code directly and install using Poetry (as of version 1.0.0)
+
 ```
-# setuptools >=42 is recommended
-$ python setup.py install
+$ poetry install
 ```
 
 Once the package is installed, the main method is hic2cool_convert. It takes the same parameters as hic2cool.py, described in the next section. Example usage in a Python script is shown below or in test.py.
@@ -119,6 +119,10 @@ You may also provide the optional `-e` flag, which will cause the mitchondrial c
 
 
 ## Changelog
+### 1.0.1
+* Restore command line usage, adds missing README update
+### 1.0.0
+*  Switch to poetry, upgraded `python`, `numpy`, `cooler` versions, h5file I/O clean up, replace `multiprocessing` with `multiprocess'
 ### 0.8.3
 * Partial fix for zlib decompression issue.
 ### 0.8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "hic2cool"
-version = "1.0.0"
+version = "1.0.1"
 description = """Converter between hic files (from juicer) and single-resolution or multi-resolution cool files (for cooler).  Both hic and cool files describe Hi-C contact matrices. Intended to be lightweight, this can be used as an imported package or a stand-alone Python tool for command line conversion."""
 authors = ["Carl Vitzthum <carl.vitzthum@gmail.com>"]
 license = "MIT"
@@ -35,6 +35,12 @@ scipy = ">=1.10.1"
 pandas = ">=1.0"
 h5py = ">=2.5.0"
 cooler = "0.9.3"
+
+
+[tool.poetry.plugins]
+
+[tool.poetry.plugins.console_scripts]
+    "hic2cool" = "hic2cool.__main__:main"
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]


### PR DESCRIPTION
Quick fix for documentation (here and pypi) and command line usage of the tool (unintentionally removed during switchover to Poetry)